### PR TITLE
Refresh proxy list from webshare every 20 minutes

### DIFF
--- a/proxy-refresh.py
+++ b/proxy-refresh.py
@@ -1,0 +1,39 @@
+import wget
+import os
+import re
+import schedule
+import time
+import datetime
+
+def get_proxies():
+    dir_path = os.path.dirname(os.path.realpath(__file__))
+    url = 'https://proxy.webshare.io/proxy/list/download/iviiinjbywzslykjrfnxutejrrqvoyunqikxjgyn/-/http/username/direct/'
+    filename = dir_path + '/' + 'config' + '/' + 'proxies.txt'
+
+    if os.path.exists(filename):
+        os.remove(filename)
+
+    wget.download(url, out=filename) 
+
+
+    pattern = re.compile("(^.*)(:)(afvlhykv:82ki6ps9x72t)")
+
+    lines = open(filename, 'r').readlines()
+
+    for i in range(len(lines)):
+        proxy = re.search(pattern, lines[i])
+        new_line = proxy.group(3) + '@' + proxy.group(1)
+        lines[i] = new_line + '\n'
+
+    out = open(filename, 'w')
+    out.writelines(lines)
+    out.close()
+
+    print("\n[" + str(datetime.datetime.now()) + "] REFRESHED PROXY LIST")
+
+get_proxies()
+
+schedule.every(20).minutes.do(get_proxies)
+while 1:
+    schedule.run_pending()
+    time.sleep(1)


### PR DESCRIPTION
### Contribution
I've created a python script that periodically downloads a user's proxy list from [WebShare](https://www.webshare.io/) every 20 minutes, and reformats them in the format required in `config/proxies.txt`. Any feedback would be appreciated :)
<br/>

**WebShare Proxy List API**
In your WebShare dashboard, click **Download Proxy List**
![image](https://user-images.githubusercontent.com/59207653/124508444-f1b97800-dd9d-11eb-98d0-3c5c3680ab31.png)
<br/>
Then, copy the Proxy List API URL:
![image](https://user-images.githubusercontent.com/59207653/124508472-0269ee00-dd9e-11eb-97dc-f7762dbd42b7.png)
<br/>


### Setup
> 🔧 Below is the setup process for the `proxy-refresh.py` file.

Change the `url` variable here to your WebShare **Proxy List API** url:
```
def get_proxies():
    dir_path = os.path.dirname(os.path.realpath(__file__))
    url = 'your-webshare-url'
    filename = dir_path + '/' + 'config' + '/' + 'proxies.txt'
```

Adjust the regex pattern using the `username` and `password` values from your WebShare dashboard:
```
pattern = re.compile("(^.*)(:)(username:password)")
```

If you'd like to adjust the scheduling interval, you can do so by changing `20` to some other value here:
```
schedule.every(20).minutes.do(get_proxies)
while 1:
    schedule.run_pending()
    time.sleep(1)
```
<br/>

### Run Script
Finally, you can run the script using the following command:
```
> python3 proxy-refresh.py
```

> 💡  Congratulations! Your proxy list will automatically refresh every 20 minutes.